### PR TITLE
FIX: increase / decrease by percent fatal error

### DIFF
--- a/jet-engine-calculated-callback.php
+++ b/jet-engine-calculated-callback.php
@@ -146,15 +146,27 @@ class Jet_Engine_Calculated_Callback_Addon {
 	public function get_config() {
 		return apply_filters( 'jet-engine-calculated-callback/config', array(
 			'increase_value_by_percentage' => function( $field_value, $percent = 0 ) {
+
+				$field_value = Jet_Engine_Calculated_Callback_Addon::prepare_value( $field_value );
+
 				if ( ! $percent ) {
 					return 'Please set percentage value to calculate';
 				}
+
+				$percent = Jet_Engine_Calculated_Callback_Addon::prepare_value( $percent );
+
 				return $field_value + $field_value * $percent / 100;
 			},
 			'decrease_value_by_percentage' => function( $field_value, $percent = 0 ) {
+				
+				$field_value = Jet_Engine_Calculated_Callback_Addon::prepare_value( $field_value );
+
 				if ( ! $percent ) {
 					return 'Please set percentage value to calculate';
 				}
+
+				$percent = Jet_Engine_Calculated_Callback_Addon::prepare_value( $percent );
+
 				return $field_value - $field_value * $percent / 100;
 			},
 			'sum_fields' => function( $field_value, $fields ) {


### PR DESCRIPTION
якщо поле яке треба збільшити на заданий процент пусте, то на PHP 8+ вилізе фатал ерор; щоб цього не було - конвертувати нечислові значення в 0